### PR TITLE
Split core functions from API

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ end)
 
 ## Why the name?
 
-It is a [visible crater](https://upload.wikimedia.org/wikipedia/commons/e/ea/Lage_des_Mondkraters_Tycho.jpg) on the moon and I thoght that'd be a nice analogy to this small gap :)
+It is a [visible crater](https://upload.wikimedia.org/wikipedia/commons/e/ea/Lage_des_Mondkraters_Tycho.jpg) on the moon and I thought that'd be a nice analogy for this small gap :)

--- a/lua/tycho/core.lua
+++ b/lua/tycho/core.lua
@@ -1,0 +1,32 @@
+-- luacheck: globals unpack vim.api
+local nvim = vim.api
+local cache = {}
+local core = {}
+
+core.register = function(namespace, fn)
+  rawset(cache, namespace, fn)
+end
+
+core.call = function(namespace, ...)
+  local fn = cache[namespace]
+  return fn(...)
+end
+
+core.map = function(namespace, kw, ...)
+  local args = {...}
+  local command = "'" .. namespace .. "'"
+  if #args >= 0 then
+    for _, i in ipairs(args) do
+      if type(i) == "string" then
+        command = command .. ", '" .. i .. "'"
+      else
+        command = command .. ", " .. i
+      end
+    end
+  end
+
+  nvim.nvim_command("map " .. kw .. " <Cmd>lua tycho.core.call(" .. command .. ")<CR>")
+end
+
+
+return {core, cache}

--- a/lua/tycho/init.lua
+++ b/lua/tycho/init.lua
@@ -1,9 +1,10 @@
 -- luacheck: globals unpack vim.api
 local nvim = vim.api
+local impl = require("tycho.core")
 local tycho = {
-  core = {},
   api = {},
-  cache = {}
+  core = impl.core,
+  cache = impl.cache
 }
 
 local sugar = {
@@ -26,36 +27,6 @@ local sugar = {
   end
 }
 
-tycho.core.register = function(namespace, fn)
-  local cache = rawget(tycho, "cache")
-  rawset(cache, namespace, fn)
-end
-
-tycho.core.call = function(namespace, ...)
-  local fn = rawget(tycho, "cache")[namespace]
-  return fn(...)
-end
-
-tycho.core.map = function(namespace, kw, ...)
-  local args = {...}
-  local command = "'" .. namespace .. "'"
-  if #args >= 0 then
-    for _, i in ipairs(args) do
-      if type(i) == "string" then
-        command = command .. ", '" .. i .. "'"
-      else
-        command = command .. ", " .. i
-      end
-    end
-  end
-
-  nvim.nvim_command("map " .. kw .. " <Cmd>lua tycho.core.call(" .. command .. ")<CR>")
-end
-
-tycho.core.debug = function()
-  print(require("inspect")(tycho))
-end
-
 tycho.api.map = function(keymap, fn)
   local func
   local ns
@@ -70,6 +41,10 @@ tycho.api.map = function(keymap, fn)
 
   tycho.core.register(ns, func)
   tycho.core.map(ns, keymap)
+end
+
+tycho.api.debug = function()
+  print(require("inspect")(tycho))
 end
 
 setmetatable(tycho, sugar)


### PR DESCRIPTION
This way it becomes clear the separation between the APIs.

Also, this allows the user to avoid using the syntatic sugar by importing `tycho.core`.